### PR TITLE
Allows to change @sysurihash as the default contentIdKey in a Page View event.

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -127,6 +127,8 @@ var MOBILEUSERAGENTS = []string{
 	"Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4",
 }
 
+var DEFAULTPAGEVIEWFIELD = "sysurihash"
+
 var SEARCHENDPOINT_PROD = "https://cloudplatform.coveo.com/rest/search/"
 var SEARCHENDPOINT_STAGING = "https://cloudplatformstaging.coveo.com/rest/search/"
 var SEARCHENDPOINT_DEV = "https://cloudplatformdev.coveo.com/rest/search/"

--- a/scenariolib/config.go
+++ b/scenariolib/config.go
@@ -221,4 +221,8 @@ func fillDefaults(c *Config) {
 	if c.AnalyticsEndpoint == "" {
 		c.AnalyticsEndpoint = defaults.ANALYTICSENDPOINT_PROD
 	}
+
+	if c.DefaultPageViewField == "" {
+		c.DefaultPageViewField = defaults.DEFAULTPAGEVIEWFIELD
+	}
 }

--- a/scenariolib/config.go
+++ b/scenariolib/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	BadQueriesInLang       map[string][]string `json:"badQueriesInLanguage"`
 	Scenarios              []*Scenario         `json:"scenarios"`
 	DefaultOriginLevel1    string              `json:"defaultOriginLevel1,omitempty"`
+	DefaultPageViewField   string              `json:"defaultPageViewField,omitempty"`
 	GlobalFilter           string              `json:"globalfilter,omitempty"`
 	SearchEndpoint         string              `json:"searchendpoint,omitempty"`
 	AnalyticsEndpoint      string              `json:"analyticsendpoint,omitempty"`

--- a/scenariolib/event_pageview.go
+++ b/scenariolib/event_pageview.go
@@ -51,10 +51,8 @@ func newViewEvent(e *JSONEvent, c *Config) (*ViewEvent, error) {
 		if event.pageViewField, validcast = e.Arguments["pageViewField"].(string); !validcast {
 			return nil, errors.New("Parameter pageViewField must be of type string in ViewEvent")
 		}
-	} else if c.DefaultPageViewField != "" {
-		event.pageViewField = c.DefaultPageViewField
 	} else {
-		event.pageViewField = "sysurihash"
+		event.pageViewField = c.DefaultPageViewField
 	}
 
 	return event, nil

--- a/scenariolib/event_pageview.go
+++ b/scenariolib/event_pageview.go
@@ -10,15 +10,16 @@ import (
 // =================================================
 
 // ViewEvent a struct representing a view, it is defined by a clickRank, an
-// offset, a probability to click and the contentType
+// offset, a probability to click, the contentType and a pageViewField
 type ViewEvent struct {
-	clickRank   int
-	offset      int
-	probability float64
-	contentType string
+	clickRank     int
+	offset        int
+	probability   float64
+	contentType   string
+	pageViewField string
 }
 
-func newViewEvent(e *JSONEvent) (*ViewEvent, error) {
+func newViewEvent(e *JSONEvent, c *Config) (*ViewEvent, error) {
 	var validcast bool
 	var offset, docNo float64
 
@@ -45,6 +46,16 @@ func newViewEvent(e *JSONEvent) (*ViewEvent, error) {
 		return nil, errors.New("Parameter docNo must be a number in a ViewEvent")
 	}
 	event.clickRank = int(docNo)
+
+	if e.Arguments["pageViewField"] != nil {
+		if event.pageViewField, validcast = e.Arguments["pageViewField"].(string); !validcast {
+			return nil, errors.New("Parameter pageViewField must be of type string in ViewEvent")
+		}
+	} else if c.DefaultPageViewField != "" {
+		event.pageViewField = c.DefaultPageViewField
+	} else {
+		event.pageViewField = "sysurihash"
+	}
 
 	return event, nil
 }
@@ -74,7 +85,7 @@ func (ve *ViewEvent) Execute(v *Visit) error {
 			return errors.New("Search results index out of bounds")
 		}
 
-		err := v.sendViewEvent(ve.clickRank, ve.contentType)
+		err := v.sendViewEvent(ve.clickRank, ve.contentType, ve.pageViewField)
 		if err != nil {
 			return err
 		}

--- a/scenariolib/events.go
+++ b/scenariolib/events.go
@@ -58,7 +58,7 @@ func ParseEvent(e *JSONEvent, c *Config) (Event, error) {
 		return event, nil
 
 	case "View":
-		event, err := newViewEvent(e)
+		event, err := newViewEvent(e, c)
 		if err != nil {
 			return nil, err
 		}

--- a/scenariolib/visit.go
+++ b/scenariolib/visit.go
@@ -215,7 +215,7 @@ func (v *Visit) sendSearchEvent(q, actionCause, actionType string, customData ma
 	return nil
 }
 
-func (v *Visit) sendViewEvent(rank int, contentType string) error {
+func (v *Visit) sendViewEvent(rank int, contentType string, pageViewField string) error {
 	Info.Printf("Sending ViewEvent rank=%d ", rank+1)
 
 	event, err := ua.NewViewEvent()
@@ -231,12 +231,13 @@ func (v *Visit) sendViewEvent(rank int, contentType string) error {
 	event.Language = v.Language
 	event.OriginLevel1 = v.OriginLevel1
 	event.OriginLevel2 = v.OriginLevel2
-	event.ContentIdKey = "@sysurihash"
+	event.ContentIdKey = "@" + pageViewField
+
 	event.PageReferrer = "Referrer"
-	if urihash, ok := v.LastResponse.Results[rank].Raw["sysurihash"].(string); ok {
-		event.ContentIdValue = urihash
+	if contentIDValue, ok := v.LastResponse.Results[rank].Raw[pageViewField].(string); ok {
+		event.ContentIdValue = contentIDValue
 	} else {
-		return errors.New("Cannot convert sysurihash to string")
+		return fmt.Errorf("Cannot convert %s field %s value to string", v.LastResponse.Results[rank].Raw[pageViewField], pageViewField)
 	}
 
 	// Send a UA view event


### PR DESCRIPTION
## Quick description (1-2 lines)

Adds the ability to change the PageView event "contentIDKey" value
## Long description (details)

We needed to log stats using our own "contentIDKey" (not sysuri).
You can now define a default `DefaultPageViewField` in the main configuration, and you can send specific events with a specific page view directly in the PageView event arguments.
