### PR TITLE
Failsafe no less than 2 QPS per bot

### DIFF
--- a/scenariolib/uabot.go
+++ b/scenariolib/uabot.go
@@ -103,7 +103,8 @@ func (bot *uabot) Run(quitChannel chan bool) error {
 
 			visit.UAClient.DeleteVisit()
 			if bot.WaitBetweenVisits {
-				waitTime := time.Duration(bot.random.Intn(timeVisits)) * time.Second
+				// Minimum wait time of 500ms between visits.
+				waitTime := (time.Duration(rand.Intn(timeVisits*1000)) + 500) * time.Millisecond
 				time.Sleep(waitTime)
 			}
 
@@ -161,8 +162,8 @@ func refreshScenarios(url string, isLocal bool) *Config {
 
 	if err != nil {
 		Warning.Println("Cannot update scenario file, keeping the old one")
+		Warning.Println(err)
 		return nil
-	} else {
-		return conf
 	}
+	return conf
 }

--- a/scenariolib/visit.go
+++ b/scenariolib/visit.go
@@ -473,7 +473,8 @@ func WaitBetweenActions(timeToWait int, isConstant bool) {
 	if isConstant {
 		time.Sleep(time.Duration(timeToWait) * time.Second)
 	} else {
-		time.Sleep(time.Duration(rand.Intn(timeToWait)) * time.Second)
+		// Failsafe to never go higher than 2 QPS per bot.
+		time.Sleep((time.Duration(rand.Intn(timeToWait*1000)) + 500) * time.Millisecond)
 	}
 
 }

--- a/scenariolib/visit.go
+++ b/scenariolib/visit.go
@@ -408,7 +408,7 @@ func (v *Visit) FindDocumentRankByTitle(toFind string) int {
 // WaitBetweenActions Wait a random or constant number of seconds between user actions
 func WaitBetweenActions(timeToWait int, isConstant bool) {
 	if isConstant {
-		time.Sleep(time.Duration(timeToWait) * time.Second)
+		time.Sleep((time.Duration(timeToWait*1000) + 500) * time.Second)
 	} else {
 		// Failsafe to never go higher than 2 QPS per bot.
 		time.Sleep((time.Duration(rand.Intn(timeToWait*1000)) + 500) * time.Millisecond)


### PR DESCRIPTION
## Description
Fixed the wait time that was always waiting between 0 and X seconds but in integer value, so giving it 1s wait, would mean the random value was always randomized between 0 and 1 but truncated to an int, so in most cases it was 0s wait.

I converted the time to wait in Milliseconds instead and added a minimum 0.5s of wait time so the bot cannot DDOS the platform.

## Where should the reviewer start?
Create a bot config with a wait time of 1s between actions it should now randomize between 0.5s and 1.5s

**Fixes issue:** #