### PR TITLE
Support DefaultPageViewField again and warn when using docNo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ export LOCAL=true #if scenariosurl is a local path
 3. Run the executable
 ```
 
+### To run tests
+```sh
+go test ./scenariolib
+```
+
 ### To trigger a Docker rebuild, push with `latest` tag
 ```sh
 1. Commit your changes

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -129,7 +129,7 @@ var MOBILEUSERAGENTS = []string{
 	"Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4",
 }
 
-var DEFAULTPAGEVIEWFIELD = "urihash"
+var DEFAULTPAGEVIEWFIELD = "permanentid"
 
 // DEFAULTORIGIN1 defaults to "All"
 var DEFAULTORIGIN1 = "All"

--- a/scenariolib/config.go
+++ b/scenariolib/config.go
@@ -89,13 +89,13 @@ type Config struct {
 
 	// DefaultOriginLevel3 Override of the default OriginLevel3.
 	DefaultOriginLevel3 string `json:"defaultOriginLevel3,omitempty"`
+
+	// DefaultPageViewField Override of the DefaultPageViewField for ALL pageView Events.
+	DefaultPageViewField string `json:"defaultPageViewField,omitempty"`
 }
 
 // RandomData An override of the bot default random/fake data.
 type RandomData struct {
-	// DefaultPageViewField Override of the DefaultPageViewField for ALL pageView Events.
-	DefaultPageViewField string `json:"defaultPageViewField,omitempty"`
-
 	// Emails Override the defaults fake emails.
 	Emails []string `json:"emailSuffixes,omitempty"`
 
@@ -202,8 +202,8 @@ func fillDefaults(c *Config) {
 		c.AnalyticsEndpoint = defaults.ANALYTICSENDPOINT_PROD
 	}
 
-	if c.RandomData.DefaultPageViewField == "" {
-		c.RandomData.DefaultPageViewField = defaults.DEFAULTPAGEVIEWFIELD
+	if c.DefaultPageViewField == "" {
+		c.DefaultPageViewField = defaults.DEFAULTPAGEVIEWFIELD
 	}
 
 	if c.DefaultOriginLevel1 == "" {

--- a/scenariolib/uabot.go
+++ b/scenariolib/uabot.go
@@ -32,6 +32,7 @@ type uabot struct {
 // NewUabot will start a bot to run some scenarios. It needs the url/path where to find the scenarions {scenarioURL},
 // the searchToken, the analyticsToken and a randomizer.
 func NewUabot(local bool, scenarioURL string, searchToken string, analyticsToken string, random *rand.Rand) Uabot {
+	rand.Seed(time.Now().UTC().UnixNano())
 	return &uabot{
 		local,
 		scenarioURL,


### PR DESCRIPTION
## Description

Using some of the previous scenarios are now very broken following https://github.com/coveo/uabot/pull/95

Here are some issues:

* `defaultPageViewField` should be used when `pageViewField` is not defined on a page view event
    * https://github.com/coveo/uabot/pull/95/files#diff-6b60f983705d44bf28f912d4844ddec5L61
* `docNo` has been deprecated in favor of `clickRank`, so the scenarios always clicks the first result instead, which is pretty hard to diagnose.
    * https://github.com/coveo/uabot/pull/95/files#diff-6faa27d6cac08114c8518b763061b1aeL45

So the whole library of scenarios in "Sitecore Commerce" is now broken.

I have started by re-implementing the missing features and at least warn when you are still using deprecated properties.