### PR TITLE
fix build condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ script:
   - go test -cover github.com/coveo/uabot/scenariolib
 before_deploy:
   - mkdir -p release
-  - "GOOS=linux GOARCH=amd64 go build -o release/uabot-$TRAVIS_TAG-linux-go$TRAVIS_GO_VERSION"
-  - "GOOS=darwin GOARCH=amd64 go build -buildmode=exe -o release/uabot-$TRAVIS_TAG-mac-go$TRAVIS_GO_VERSION"
-  - "GOOS=windows GOARCH=amd64 go build -o release/uabot-$TRAVIS_TAG-windows-go$TRAVIS_GO_VERSION.exe"
+  - "GOOS=linux GOARCH=amd64 go build -o release/uabot-$TRAVIS_TAG-linux"
+  - "GOOS=darwin GOARCH=amd64 go build -buildmode=exe -o release/uabot-$TRAVIS_TAG-mac"
+  - "GOOS=windows GOARCH=amd64 go build -o release/uabot-$TRAVIS_TAG-windows.exe"
 deploy:
   provider: releases
   api_key:
@@ -21,3 +21,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+    condition: $TRAVIS_GO_VERSION =~ ^1\.9


### PR DESCRIPTION
## Description
The doc on the condition was wrong, TRAVIS_GO_VERSION was not expanded to 1.9.4, but was 1.9.x

https://docs.travis-ci.com/user/languages/go/

## Where should the reviewer start?

The artefacts created with go 1.9.4 and buildmode=exe on mac were working. 
I will create tag v0.4.1 once this PR is merged.

**Fixes issue:** 
Condition is necessary so "tip" don't override the release artefacts from 1.9