### PR TITLE
Fixed a few breaking that occured with the refactoring of events.

### DIFF
--- a/scenariolib/config.go
+++ b/scenariolib/config.go
@@ -89,12 +89,13 @@ type Config struct {
 
 	// DefaultOriginLevel3 Override of the default OriginLevel3.
 	DefaultOriginLevel3 string `json:"defaultOriginLevel3,omitempty"`
+
+	// DefaultPageViewField Override of the DefaultPageViewField for ALL pageView Events.
+	DefaultPageViewField string `json:"defaultPageViewField,omitempty"`
 }
 
 // RandomData An override of the bot default random/fake data.
 type RandomData struct {
-	// DefaultPageViewField Override of the DefaultPageViewField for ALL pageView Events.
-	DefaultPageViewField string `json:"defaultPageViewField,omitempty"`
 
 	// Emails Override the defaults fake emails.
 	Emails []string `json:"emailSuffixes,omitempty"`
@@ -202,8 +203,8 @@ func fillDefaults(c *Config) {
 		c.AnalyticsEndpoint = defaults.ANALYTICSENDPOINT_PROD
 	}
 
-	if c.RandomData.DefaultPageViewField == "" {
-		c.RandomData.DefaultPageViewField = defaults.DEFAULTPAGEVIEWFIELD
+	if c.DefaultPageViewField == "" {
+		c.DefaultPageViewField = defaults.DEFAULTPAGEVIEWFIELD
 	}
 
 	if c.DefaultOriginLevel1 == "" {

--- a/scenariolib/event_pageview_test.go
+++ b/scenariolib/event_pageview_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPageViewEventValid(t *testing.T) {
-	var testEventJson = []byte(`{"clickRank": 1, "probability": 0.5, "pageViewField": "pageViewFieldTest", "offset": 0, "contentType": "contentTypeTest", "customData": {"data1": "one"}}`)
+	var testEventJson = []byte(`{"docNo": 1, "probability": 0.5, "pageViewField": "pageViewFieldTest", "offset": 0, "contentType": "contentTypeTest", "customData": {"data1": "one"}}`)
 	event := &scenariolib.ViewEvent{}
 
 	// Test unmarshal json.


### PR DESCRIPTION
## Description
Reset the param name for pageView to docNo.
Fixed the computeClickRank for clicks and pageViews
Fixed the pageViewTest.
Reset the DefaultPageViewField to be top level in config.

Credits to @francoislg for these fixes.