### PR TITLE
add -trace to the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Check the [/scenarios_examples](https://github.com/coveo/uabot/tree/master/scena
 3. Build your scenarios ([How to build scenarios](http://coveo.github.io/uabot/scenario.html)).
 4. Execute the bot.
 
+### Tracing
+
+You can use the argument `-trace` to get more logs when debugging your scenarios.
+
 [Examples of scenarios](https://github.com/coveo/uabot/tree/master/scenarios_examples)
 
 <hr/>

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -12,7 +13,17 @@ import (
 
 func main() {
 	// Init loggers
-	scenariolib.InitLogger(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr)
+
+	tracePtr := flag.Bool("trace", false, "enable TRACE")
+	flag.Parse()
+
+	traceOut := ioutil.Discard
+	if *tracePtr {
+		pp.Println("TRACE enabled")
+		traceOut = os.Stdout
+	}
+
+	scenariolib.InitLogger(traceOut, os.Stdout, os.Stdout, os.Stderr)
 
 	// Seed Random based on current time
 	source := rand.NewSource(int64(time.Now().Unix()))

--- a/scenariolib/visit.go
+++ b/scenariolib/visit.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"math"
 	"math/rand"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -60,8 +58,6 @@ const (
 // _uatoken     The token used to send usage analytics events
 // _useragent   The user agent the analytics events will see
 func NewVisit(_searchtoken string, _uatoken string, _useragent string, language string, c *Config) (*Visit, error) {
-
-	InitLogger(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr)
 
 	v := Visit{}
 	v.Config = c
@@ -322,6 +318,7 @@ func (v *Visit) FindDocumentRankByMatchingField(field string, regexPattern *rege
 	}
 	for i := 0; i < len(v.LastResponse.Results); i++ {
 		if rawValue, ok := v.LastResponse.Results[i].Raw[field].(string); ok {
+			Trace.Printf("Checking raw value (field=%s) \"%s\" with pattern \"%s\"", field, rawValue, regexPattern.String())
 			if regexPattern.MatchString(rawValue) {
 				return i
 			}


### PR DESCRIPTION
## Description
It can be useful to get more logs when debugging scenarios. 
Rather than simply ignoring the Trace in the Logger, I added support for an argument `-trace` when running the ua-bot.

There was no need to re-initialise the Logger in visit.go. 