### PR TITLE
Use queryText in SearchAndClick (as Search)

### DIFF
--- a/scenariolib/event_searchandclick.go
+++ b/scenariolib/event_searchandclick.go
@@ -13,7 +13,7 @@ import (
 // SearchAndClickEvent represents a search event followed by a click on a specific
 // document found by the title
 type SearchAndClickEvent struct {
-	Query        string                 `json:"query"`
+	Query        string                 `json:"queryText"`
 	Probability  float64                `json:"probability"`
 	DocTitle     string                 `json:"docClickTitle,omitempty"`
 	MatchField   string                 `json:"matchField,,omitempty"`

--- a/scenariolib/event_searchandclick_test.go
+++ b/scenariolib/event_searchandclick_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSearchAndClickEventValid(t *testing.T) {
-	var testEventJson = []byte(`{"query": "queryTextTest", "probability": 0.5, "docClickTitle": "docTitleTest", "quickview": false, "caseSearch": false, "inputTitle": "inputTitleTest", "customData": {"data1": "one"}}`)
+	var testEventJson = []byte(`{"queryText": "queryTextTest", "probability": 0.5, "docClickTitle": "docTitleTest", "quickview": false, "caseSearch": false, "inputTitle": "inputTitleTest", "customData": {"data1": "one"}}`)
 	event := &scenariolib.SearchAndClickEvent{}
 
 	// Test unmarshal json.


### PR DESCRIPTION
## Description
Use `queryText` in SearchAndClickEvent to be consistent with SearchEvent.
(I believe it used to be like that because my scenario DemoMovies.json was written with `queryText`)

