### PR TITLE
Fix random seed and add 'seed' as parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ func main() {
 	// Init loggers
 
 	tracePtr := flag.Bool("trace", false, "enable TRACE")
+	seedPtr := flag.Int64("seed", -1, "set the Randomizer seed")
+
 	flag.Parse()
 
 	traceOut := ioutil.Discard
@@ -25,9 +27,14 @@ func main() {
 
 	scenariolib.InitLogger(traceOut, os.Stdout, os.Stdout, os.Stderr)
 
-	// Seed Random based on current time
-	source := rand.NewSource(int64(time.Now().Unix()))
-	random := rand.New(source)
+	seed := *seedPtr
+	if seed == -1 {
+		// Seed Random based on current time
+		seed = int64(time.Now().Unix())
+	}
+	scenariolib.Trace.Printf("Ramdom seed: %d", seed)
+
+	rand.Seed(seed)
 
 	searchToken := os.Getenv("SEARCHTOKEN")
 	analyticsToken := os.Getenv("UATOKEN")
@@ -45,7 +52,7 @@ func main() {
 		scenariolib.Info.Println("STARTING IN LOCAL MODE, MAKE SURE THE SCENARIOSURL IS A LOCAL PATH")
 	}
 
-	bot := scenariolib.NewUabot(local, scenarioURL, searchToken, analyticsToken, random)
+	bot := scenariolib.NewUabot(local, scenarioURL, searchToken, analyticsToken)
 
 	quit := make(chan bool)
 	err := bot.Run(quit)

--- a/scenariolib/uabot.go
+++ b/scenariolib/uabot.go
@@ -25,19 +25,17 @@ type uabot struct {
 	scenarioURL       string
 	searchToken       string
 	analyticsToken    string
-	random            *rand.Rand
 	WaitBetweenVisits bool
 }
 
 // NewUabot will start a bot to run some scenarios. It needs the url/path where to find the scenarions {scenarioURL},
 // the searchToken, the analyticsToken and a randomizer.
-func NewUabot(local bool, scenarioURL string, searchToken string, analyticsToken string, random *rand.Rand) Uabot {
+func NewUabot(local bool, scenarioURL string, searchToken string, analyticsToken string) Uabot {
 	return &uabot{
 		local,
 		scenarioURL,
 		searchToken,
 		analyticsToken,
-		random,
 		true,
 	}
 }
@@ -135,7 +133,7 @@ func (bot *uabot) continuallyUpdateTimeVisitsEvery(timeDuration time.Duration, t
 				effectiveMeanTimeBetweenVisits = DEFAULTTIMEBETWEENVISITS * WEEKEND_MODIFIER
 			}
 			var randomPositiveTime int
-			for randomPositiveTime = 0; randomPositiveTime <= 0; randomPositiveTime = int(float64(DEFAULT_STANDARD_DEVIATION_BETWEEN_VISITS)*bot.random.NormFloat64()+0.5) + effectiveMeanTimeBetweenVisits {
+			for randomPositiveTime = 0; randomPositiveTime <= 0; randomPositiveTime = int(float64(DEFAULT_STANDARD_DEVIATION_BETWEEN_VISITS)*rand.NormFloat64()+0.5) + effectiveMeanTimeBetweenVisits {
 			}
 			*timeVisits = randomPositiveTime
 			Info.Println("Updating Time Visits to", *timeVisits)


### PR DESCRIPTION
## Description
I noticed the Random function wasn't working: It was random, but always in the same order. 

We don't need to pass a Random object around, we simply need to set `rand.Seed()` once. Then all call to `math/rand` will be randomize. 

It can be useful to set the _seed_ directly to run the bot in a predictable fashion (ie. unit tests), so I added support for a `-seed` parameter.