### PR TITLE
Unit tests for DecorateEvent

### DIFF
--- a/scenariolib/event_searchandclick_test.go
+++ b/scenariolib/event_searchandclick_test.go
@@ -2,6 +2,11 @@ package scenariolib_test
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/coveo/uabot/scenariolib"
@@ -35,4 +40,108 @@ func TestSearchAndClickEventValid(t *testing.T) {
 
 	// Expect CustomData["data1"] to be "one"
 	equals(t, "one", event.CustomData["data1"])
+}
+
+type ExpectedRequest struct {
+	Method  string
+	Headers map[string]string
+	Body    []byte
+}
+
+// JSONBytesEqual compares the JSON in two byte slices.
+func JSONBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(j2, j), nil
+}
+
+func TestDecorateSearchAndClickEvent(t *testing.T) {
+	scenariolib.InitLogger(os.Stdout, os.Stdout, os.Stdout, os.Stderr)
+
+	expected := map[string]ExpectedRequest{
+		"/rest/search/": {
+			"POST",
+			map[string]string{
+				"Authorization": "Bearer bot.searchToken",
+				"Content-Type":  "application/json",
+			},
+			[]byte(`{
+				"q": "aaaaaaaaaaa",
+				"numberOfResults": 20,
+				"tab": "All",
+				"pipeline": "besttechCommunity"
+			}`),
+		},
+		"/rest/v15/analytics/search/": {
+			"POST",
+			map[string]string{
+				"Authorization": "Bearer bot.analyticsToken",
+				"Content-Type":  "application/json",
+			},
+			[]byte(`{
+					"language": "en",
+					"device": "Bot",
+					"customData": {
+						"JSUIVersion": "0.0.0.0;0.0.0.0",
+						"customData1": "customValue 1",
+						"ipaddress": "216.249.112.8"
+					},
+					"anonymous": true,
+					"originLevel1": "BotSearch",
+					"originLevel2": "",
+					"searchQueryUid": "",
+					"queryText": "aaaaaaaaaaa",
+					"actionCause": "searchboxSubmit",
+					"contextual": false
+				}`),
+		},
+	}
+
+	// Start a local HTTP server to intercept requests
+	// Using url to match the expected responses above.
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		url := req.URL.String()
+
+		expReq, exists := expected[url]
+		assert(t, exists, "MISSING expected request for %s", url)
+
+		// Test request parameters
+		equals(t, req.Method, expReq.Method)
+
+		for k, v := range expReq.Headers {
+			equals(t, v, req.Header.Get(k))
+		}
+
+		// body is JSON
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		eq, err := JSONBytesEqual(expReq.Body, body)
+		assert(t, eq, "JSON from body is not what we expected\nGot: %s\nExp: %s", body, req.Body)
+
+		// Send back a static response
+		rw.Write([]byte(`{"status":"OK"}`))
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	event := &scenariolib.SearchAndClickEvent{}
+	conf, err := scenariolib.NewConfigFromPath("../scenarios_examples/TESTScenarios.json")
+	ok(t, err)
+
+	// Use the server url to define the endpoints
+	conf.SearchEndpoint = server.URL + "/rest/search/"
+	conf.AnalyticsEndpoint = server.URL + "/rest/v15/analytics/"
+
+	v, err := scenariolib.NewVisit("bot.searchToken", "bot.analyticsToken", "scenario.UserAgent", "en", conf)
+
+	v.SetupGeneral()
+	event.Execute(v)
 }

--- a/scenariolib/uabot_test.go
+++ b/scenariolib/uabot_test.go
@@ -1,7 +1,11 @@
 package scenariolib_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -42,4 +46,54 @@ func equals(tb testing.TB, exp, act interface{}) {
 		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, exp, act)
 		tb.FailNow()
 	}
+}
+
+type ExpectedRequest struct {
+	Method  string
+	Headers map[string]string
+	Body    []byte
+}
+
+// JSONBytesEqual compares the JSON in two byte slices.
+func JSONBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(j2, j), nil
+}
+
+func createMockServer(t testing.TB, expected map[string]ExpectedRequest) *httptest.Server {
+	// Start a local HTTP server to intercept requests
+	// Using url to match the expected responses above.
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		url := req.URL.String()
+
+		expReq, exists := expected[url]
+		assert(t, exists, "MISSING expected request for %s", url)
+
+		// Test request parameters
+		equals(t, req.Method, expReq.Method)
+
+		for k, v := range expReq.Headers {
+			equals(t, v, req.Header.Get(k))
+		}
+
+		// body is JSON
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		eq, err := JSONBytesEqual(expReq.Body, body)
+		assert(t, eq, "JSON from body is not what we expected\nGot: %s\nExp: %s", body, req.Body)
+
+		// Send back a static response
+		rw.Write([]byte(`{"status":"OK"}`))
+	}))
+
+	return server
 }

--- a/scenarios_examples/DemoMovies.json
+++ b/scenarios_examples/DemoMovies.json
@@ -10,8 +10,8 @@
   "anonymousThreshold": 0.3,
   "timeBetweenVisits": 2,
   "timeBetweenActions": 1,
-  "randomGoodQueries": [],
-  "randomBadQueries": [],
+  "randomGoodQueries": ["Ghostbusters"],
+  "randomBadQueries": ["Gostbuster"],
   "randomCustomData": [{"apiname": "c_isbot", "values": ["true"]}],
   "globalFilter": "@mytype=Movie",
   "scenarios": [{


### PR DESCRIPTION
## Description

Create a Mock Http Server with a ExpectedRequest structure to define what is expected as request payloads.

It improves the coverage from 3.1% to 26.1%
